### PR TITLE
feat(node): use build time arg for node installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ sudo: required
 services:
   - docker
 
+env:
+  global:
+  - NODE_VERSION=8.4.0
+  - NPM_VERSION=5.4.0
+
 matrix:
   # let whole build fails if one of matrix build config fails
   fast_finish: true
@@ -25,8 +30,8 @@ script:
   # set docker tag based on build jobs.
   - DOCKER_TAG=$DOCKER_REPO:${TRAVIS_TAG:-$TRAVIS_BUILD_NUMBER}
   - cd $DOCKERFILE
-  - tput setaf 2; echo building docker image for $DOCKERFILE tagged as $DOCKER_TAG at $(pwd)
-  - sudo docker build --tag $DOCKER_TAG .
+  - tput setaf 2; echo building docker image for $DOCKERFILE tagged as $DOCKER_TAG at $(pwd), with node $NODE_VERSION / npm $NPM_VERSION
+  - sudo docker build --build-arg NODE_VERSION=$NODE_VERSION --build-arg NPM_VERSION=$NPM_VERSION  --tag $DOCKER_TAG .
   - |
     if [[ ! -z "${TRAVIS_TAG}" ]]; then
       tput setaf 2; echo this build is tagged versioned build, pushing into registry

--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -2,6 +2,10 @@
 FROM antergos/archlinux-base-devel
 MAINTAINER OJ Kwon <kwon.ohjoong@gmail.com>
 
+# Set default node, npm version to install if not specified
+ARG NODE_VERSION=7.9.0
+ARG NPM_VERSION=4
+
 # Update installed packages
 RUN pacman --noconfirm -Syy && pacman --noconfirm -Su
 
@@ -56,8 +60,7 @@ RUN mkdir $TMPDIR \
 # Set makepkg ext configuration to archive into .xz
 ENV PKGEXT='.pkg.tar.xz'
 
-# Set node version to install
-ENV NODE_VERSION=7.9.0
+
 ENV NVM_DIR=$HOME/.nvm
 
 # Install node and npm
@@ -65,7 +68,7 @@ RUN source /usr/share/nvm/init-nvm.sh \
     && nvm install $NODE_VERSION \
     && nvm alias default $NODE_VERSION \
     && nvm use default \
-    && npm install -g npm@4
+    && npm install -g npm@$NPM_VERSION
 
 # add node and npm to path so the commands are available
 ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
@@ -74,4 +77,5 @@ ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 # reset user to root after makepkg completes
 USER root
 
-CMD node --version && npm --version
+RUN node --version && npm --version
+CMD echo 'done'

--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -2,6 +2,10 @@
 FROM fedora:21
 MAINTAINER OJ Kwon <kwon.ohjoong@gmail.com>
 
+# Set default node, npm version to install if not specified
+ARG NODE_VERSION=7.9.0
+ARG NPM_VERSION=4
+
 # Install base dependencies
 RUN rpm --rebuilddb; yum install -y \
     sudo \
@@ -55,8 +59,6 @@ RUN set -ex \
     gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
   done
 
-ENV NODE_VERSION 7.9.0
-
 # install node, then update npm to 4.0.5
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
@@ -65,7 +67,7 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
   && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
-  && npm install -g npm@4
+  && npm install -g npm@$NPM_VERSION
 
 # Setting passwordless sudo
 RUN echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
@@ -75,4 +77,5 @@ RUN useradd -mr builder
 ENV HOME=/home/builder
 ENV TMPDIR=/home/builder/temp
 
-CMD node --version && npm --version
+RUN node --version && npm --version
+CMD echo 'done'

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -2,6 +2,10 @@
 FROM ubuntu:trusty
 MAINTAINER OJ Kwon <kwon.ohjoong@gmail.com>
 
+# Set default node, npm version to install if not specified
+ARG NODE_VERSION=7.9.0
+ARG NPM_VERSION=4
+
 # Install base dependencies
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     sudo \
@@ -53,8 +57,6 @@ RUN set -ex \
     gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
   done
 
-ENV NODE_VERSION 7.9.0
-
 # install node, then update npm to 4.0.5
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
@@ -63,7 +65,7 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
   && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
-  && npm install -g npm@4
+  && npm install -g npm@$NPM_VERSION
 
 # bump up gcc to 4.9
 RUN apt-get install -y software-properties-common --no-install-recommends
@@ -80,4 +82,5 @@ RUN useradd -mr builder
 ENV HOME=/home/builder
 ENV TMPDIR=/home/builder/temp
 
-CMD node --version && npm --version
+RUN node --version && npm --version
+CMD echo 'done'


### PR DESCRIPTION
This PR extracts out node / npm version via `--build-arg` build time args, and bumps up to latest.