### PR TITLE
fix(arch): install nodejs directly instead of nvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 
 env:
   global:
-  - NODE_VERSION=9.5.0
+  - NODE_VERSION=9.6.1
   - NPM_VERSION=5.7.1
 
 matrix:

--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -1,6 +1,5 @@
 # Base docker image
 FROM antergos/archlinux-base-devel
-MAINTAINER OJ Kwon <kwon.ohjoong@gmail.com>
 
 # Set default node, npm version to install if not specified
 ARG NODE_VERSION=8.9.1
@@ -62,7 +61,13 @@ ENV PKGEXT='.pkg.tar.xz'
 
 ENV NVM_DIR=$HOME/.nvm
 
-# Install node and npm
+# Install arch pkg nodejs first
+RUN mkdir -p /home/builder/node-tmp && cd /home/builder/node-tmp && \
+  curl https://archive.archlinux.org/packages/n/nodejs/nodejs-$NODE_VERSION-1-x86_64.pkg.tar.xz > ./nodejs-$NODE_VERSION-1-x86_64.pkg.tar.xz && \
+  curl https://archive.archlinux.org/packages/n/nodejs/nodejs-$NODE_VERSION-1-x86_64.pkg.tar.xz.sig > ./nodejs-$NODE_VERSION-1-x86_64.pkg.tar.xz.sig && \
+  sudo pacman --noconfirm -U nodejs-$NODE_VERSION-1-x86_64.pkg.tar.xz
+
+# Install node via nvm, bump up npm
 RUN source /usr/share/nvm/init-nvm.sh \
     && nvm install $NODE_VERSION \
     && nvm alias default $NODE_VERSION \

--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -1,6 +1,5 @@
 # Base docker image
 FROM fedora:21
-MAINTAINER OJ Kwon <kwon.ohjoong@gmail.com>
 
 # Set default node, npm version to install if not specified
 ARG NODE_VERSION=8.9.1

--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -69,9 +69,9 @@ RUN set -ex \
     56730D5401028683275BD23C23EFEFE93C4CFFFE \
     77984A986EBC2AA786BC0F66B01FBB92821C587A \
   ; do \
-    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
-    gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" ; \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
 # install node, then update npm to specified version

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -62,9 +62,9 @@ RUN set -ex \
     56730D5401028683275BD23C23EFEFE93C4CFFFE \
     77984A986EBC2AA786BC0F66B01FBB92821C587A \
   ; do \
-    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
-    gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" ; \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
 # install node, then update npm to specified version

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,6 +1,5 @@
 # Base docker image
 FROM ubuntu:xenial
-MAINTAINER OJ Kwon <kwon.ohjoong@gmail.com>
 
 # Set default node, npm version to install if not specified
 ARG NODE_VERSION=8.9.1


### PR DESCRIPTION
This PR installs arch's nodejs corresponding to version to be installed for nvm to align node dependencies.