### PR TITLE
feat(updpkgsums): add pacman-contrib dependency

### DIFF
--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -34,7 +34,8 @@ RUN pacman --noconfirm -Sy \
   openssl \
   c-ares \
   http-parser \
-  xorg-server-xvfb
+  xorg-server-xvfb \
+  pacman-contrib
 
 RUN git --version
 


### PR DESCRIPTION
With latest arch update, `updpkgsums` to generate integrity for pkgbuild now moved into `pacman-contrib` pkg.